### PR TITLE
11 hacerlo universal para los demas engines

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -59,21 +59,21 @@ def remove_all_drivers_and_stretch_constraints(armature_obj):
                     new_constraint.target = ct.target
                     new_constraint.subtarget = ct.subtarget
                     bone.constraints.remove(ct)
-
-            # Add Limit Scale constraint
-            limit_scale = bone.constraints.new('LIMIT_SCALE')
-            limit_scale.use_min_x = True
-            limit_scale.use_min_y = True
-            limit_scale.use_min_z = True
-            limit_scale.use_max_x = True
-            limit_scale.use_max_y = True
-            limit_scale.use_max_z = True
-            limit_scale.min_x = 1.0
-            limit_scale.min_y = 1.0
-            limit_scale.min_z = 1.0
-            limit_scale.max_x = 1.0
-            limit_scale.max_y = 1.0
-            limit_scale.max_z = 1.0
+            if bone.name not in ["DEF-eye.L","DEF-eye.R","DEF-jaw"]:
+                # Add Limit Scale constraint
+                limit_scale = bone.constraints.new('LIMIT_SCALE')
+                limit_scale.use_min_x = True
+                limit_scale.use_min_y = True
+                limit_scale.use_min_z = True
+                limit_scale.use_max_x = True
+                limit_scale.use_max_y = True
+                limit_scale.use_max_z = True
+                limit_scale.min_x = 1.0
+                limit_scale.min_y = 1.0
+                limit_scale.min_z = 1.0
+                limit_scale.max_x = 1.0
+                limit_scale.max_y = 1.0
+                limit_scale.max_z = 1.0
 
             # Special case: thigh or shin
             if "thigh" in bone.name.lower() or "shin" in bone.name.lower():


### PR DESCRIPTION
Massive Merge with breaking changes for former animations.

As part of the hard work done by @Quaternius, I've modified the script to accommodate all the game engines, and not just Godot. the following changes are now done to avoid errors on the the various engines:

ScaleLimits are set on most bones to 1,1,1 
Stretch is set to 0
Copy Transforms for control nodes are changed to Copy Rotation instead since rotation info is more useful for retargets anyway, you get more faithful retargeting in engines.
To appease the Unreal Engine retargeting gods there are now leave bones added to fingers.
Renamed the rig to "Armature" 
And the bone names have been renamed to match more typical standards across all engines.

**NOTE:**
The bone renaming will affect compatibility with former animations if you plant to mix and match animations made on the former Rigoditify versions with this one. So i will create a Gist script to assist with that. It can be used to rename your vertex groups and bones to the new standard, so that old animations work on the new rig. This won't be necessary for new animations on the new rig, only for those of you mixing and matching their old and new in blender.


